### PR TITLE
Minimal env yml, change urdfpy to urchin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,58 +1,16 @@
-name: test
+name: controls_env
 channels:
-  - defaults
   - conda-forge
+
 dependencies:
-  - _libgcc_mutex=0.1=main
-  - _openmp_mutex=5.1=1_gnu
-  - bzip2=1.0.8=h5eee18b_6
-  - ca-certificates=2025.9.9=h06a4308_0
-  - expat=2.7.1=h6a678d5_0
-  - ld_impl_linux-64=2.40=h12ee557_0
-  - libffi=3.4.4=h6a678d5_1
-  - libgcc-ng=11.2.0=h1234567_1
-  - libgomp=11.2.0=h1234567_1
-  - libstdcxx-ng=13.2.0=hc0a3c3a_7
-  - libuuid=1.41.5=h5eee18b_0
-  - libxcb=1.17.0=h9b100fa_0
-  - libzlib=1.3.1=hb25bd0a_0
-  - ncurses=6.5=h7934f7d_0
-  - openssl=3.0.17=h5eee18b_0
-  - pip=25.2=pyhc872135_0
-  - pthread-stubs=0.3=h0ce48e5_1
-  - python=3.10.18=h1a3bd86_0
-  - readline=8.3=hc2a1206_0
-  - setuptools=78.1.1=py310h06a4308_0
-  - sqlite=3.50.2=hb25bd0a_1
-  - tk=8.6.15=h54e0aa7_0
-  - tzdata=2025b=h04d1e81_0
-  - wheel=0.45.1=py310h06a4308_0
-  - xorg-libx11=1.8.12=h9b100fa_1
-  - xorg-libxau=1.0.12=h9b100fa_0
-  - xorg-libxdmcp=1.1.5=h9b100fa_0
-  - xorg-xorgproto=2024.1=h5eee18b_1
-  - xz=5.6.4=h5eee18b_1
-  - zlib=1.3.1=hb25bd0a_0
+  - python=3.10
+  - pip
+  - mujoco
+  - numpy
+  - scipy
+
   - pip:
-      - absl-py==2.3.1
-      - decorator==5.2.1
-      - networkx==2.2
-      - etils==1.13.0
-      - freetype-py==2.5.1
-      - glfw==2.10.0
-      - imageio==2.37.0
-      - importlib-resources==6.5.2
-      - lxml==6.0.2
-      - mujoco==3.3.6
-      - numpy==1.23.5
-      - pillow==11.3.0
-      - pycollada==0.6
-      - pyglet==2.1.9
-      - pyopengl==3.1.0
-      - pyrender==0.1.45
-      - python-dateutil==2.9.0.post0
-      - scipy==1.15.3
-      - six==1.17.0
-      - trimesh==4.8.3
-      - urdfpy==0.0.22
-      - zipp==3.23.0
+    - urchin
+    - networkx
+    - trimesh
+    - pyrender

--- a/scripts/model.py
+++ b/scripts/model.py
@@ -1,4 +1,4 @@
-from urdfpy import URDF
+from urchin import URDF
 import numpy as np
 
 


### PR DESCRIPTION
Hi! I was interested in trying your implementation of IK for the SO-101 but couldn't run things as-is on MacOS. I think this fixes things?

Changes:
* Edit `environment.yml` to be named `controls_env` again and only include dependencies required by the library.
  * The current file appears to be an export from Linux that includes os-specific and incidental dependencies.
* Update dependency and code to use [`urchin`](https://github.com/fishbotics/urchin) instead of `urdfpy`. `urdfpy` is no longer maintained and requires old versions causing conflicts with other packages. `urchin` is a community-maintained fork mentioned in the issues of `urdfpy` and seems to be the best current option?

Testing:
* Ran unit test script and the 2 main scripts and saw expected outputs.

Caveats:
* Haven't actually *tried* the library yet, so hopefully this is sufficient.
* Pruned the dependencies manually, possible I cut something that just wasn't used in the unit tests.